### PR TITLE
fix: set features in docs.rs build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ sqlite = ["sqlx/sqlite"]
 runtime-tokio-native-tls = ["sqlx/runtime-tokio-native-tls"]
 runtime-tokio-rustls = ["sqlx/runtime-tokio-rustls"]
 
+[package.metadata.docs.rs]
+features = ["all-databases", "runtime-tokio-rustls"]
+
 [dependencies]
 axum-core = "0.1.2"
 futures = "0.3.21"


### PR DESCRIPTION
- 9f41750 **fix: set features in docs.rs build**

  The docs.rs build is failing because one of the `runtime` features is
  required.
