### PR TITLE
Mutex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+*.sublime-workspace
 /target
 Cargo.lock

--- a/.sublime-project
+++ b/.sublime-project
@@ -1,0 +1,17 @@
+{
+  "folders": [
+    {
+      "path": "."
+    }
+  ],
+  "settings": {
+    "LSP": {
+      "rust-analyzer": {
+        "settings": {
+          "rust-analyzer.cargo.allFeatures": false,
+          "rust-analyzer.cargo.features": ["all-databases", "runtime-tokio-rustls"]
+        }
+      }
+    }
+  }
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-sqlx-tx"
 description = "Request-scoped SQLx transactions for axum"
-version = "0.1.0"
+version = "0.1.1"
 license = "MIT"
 repository = "https://github.com/wasdacraic/axum-sqlx-tx/"
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ features = ["all-databases", "runtime-tokio-rustls"]
 
 [dependencies]
 axum-core = "0.1.2"
-futures = "0.3.21"
+futures-core = "0.3.21"
 http = "0.2.6"
 parking_lot = "0.12.0"
 sqlx = { version = "0.5.11", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ features = ["all-databases", "runtime-tokio-rustls"]
 axum-core = "0.1.2"
 futures = "0.3.21"
 http = "0.2.6"
+parking_lot = "0.12.0"
 sqlx = { version = "0.5.11", default-features = false }
 thiserror = "1.0.30"
 tower-layer = "0.3.1"

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -1,6 +1,6 @@
 //! A [`tower_layer::Layer`] that enables the [`Tx`](crate::Tx) extractor.
 
-use futures::future::BoxFuture;
+use futures_core::future::BoxFuture;
 
 use crate::tx::TxSlot;
 

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -57,7 +57,7 @@ impl<DB: sqlx::Database, B: Send> FromRequest<B> for Tx<DB> {
 
     fn from_request<'req, 'ctx>(
         req: &'req mut RequestParts<B>,
-    ) -> futures::future::BoxFuture<'ctx, Result<Self, Self::Rejection>>
+    ) -> futures_core::future::BoxFuture<'ctx, Result<Self, Self::Rejection>>
     where
         'req: 'ctx,
         Self: 'ctx,
@@ -150,7 +150,7 @@ impl<DB: sqlx::Database> Lazy<DB> {
     feature = "sqlite"
 ))]
 mod sqlx_impls {
-    use futures::{future::BoxFuture, stream::BoxStream};
+    use futures_core::{future::BoxFuture, stream::BoxStream};
 
     macro_rules! impl_executor {
         ($db:path) => {


### PR DESCRIPTION
- 8afc9e9 **refactor: use an `Arc<Mutex<Option<_>>>` for `slot`**

  This should be a bit smaller and more efficient than the `oneshot`
  shenanigans since `oneshot` itself uses an `Arc` and several locks
  internally.

- 27f5022 **chore: use `futures-core` rather than `futures`**

  Now that we don't need `futures::channel::oneshot` we can get away with
  only `futures-core`.

- e5f9710 **chore: add `.sublime-project`**

  Since we need some features to be enabled for `rust-analyzer` to run
  properly, it makes sense to put them in a project-specific
  configuration.

- 353d6b9 **chore: bump version**

