### PR TITLE
Release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,21 @@
+name: release
+
+on:
+  push:
+    tags: '[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: --no-verify
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,12 @@ version = "0.1.1"
 license = "MIT"
 repository = "https://github.com/wasdacraic/axum-sqlx-tx/"
 edition = "2021"
+include = [
+  "LICENSE",
+  "README.md",
+  "Cargo.toml",
+  "**/*.rs"
+]
 
 [features]
 all-databases = ["any", "mssql", "mysql", "postgres", "sqlite"]


### PR DESCRIPTION
- be0673a **ci: add a simple release workflow**

  Currently this just invokes `cargo publish` when a semver tag is pushed
  to the repo. Ideally there should be some extra verification and/or
  automation around the version number, but this gets it off my laptop for
  now.