### PR TITLE
Docs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -6,20 +6,6 @@ on:
       - master
 
 jobs:
-  fmt:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: default
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check
-          
   clippy:
     strategy:
       fail-fast: false
@@ -41,12 +27,39 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          profile: default
           override: true
+          components: clippy
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: --features '${{ matrix.db }} ${{ matrix.db_any }} ${{ matrix.runtime }}' -- -D warnings
+
+  doc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --features runtime-tokio-rustls,all-databases
+
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: -- --check
           
   test:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-sqlx-tx"
 description = "Request-scoped SQLx transactions for axum"
-version = "0.1.1"
+version = "0.1.2"
 license = "MIT"
 repository = "https://github.com/wasdacraic/axum-sqlx-tx/"
 edition = "2021"

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,0 +1,84 @@
+//! A silly server that generates random numers, but only commits positive ones.
+
+use std::error::Error;
+
+use axum::{error_handling::HandleErrorLayer, response::IntoResponse, routing::get, Json};
+use http::StatusCode;
+
+// OPTIONAL: use a type alias to avoid repeating your database type
+type Tx = axum_sqlx_tx::Tx<sqlx::Sqlite>;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    // You can use any sqlx::Pool
+    let db = tempfile::NamedTempFile::new()?;
+    let pool = sqlx::SqlitePool::connect(&format!("sqlite://{}", db.path().display())).await?;
+
+    // Create a table (in a real application you might run migrations)
+    sqlx::query("CREATE TABLE IF NOT EXISTS numbers (number INT PRIMARY KEY);")
+        .execute(&pool)
+        .await?;
+
+    // Standard axum app setup
+    let app = axum::Router::new()
+        .route("/numbers", get(list_numbers).post(generate_number))
+        .layer(
+            // Apply the Tx middleware
+            tower::ServiceBuilder::new()
+                .layer(HandleErrorLayer::new(|error: sqlx::Error| async move {
+                    // The transaction is committed by the middleware so an error is possible
+                    // and must be converted into a response.
+                    DbError(error)
+                }))
+                .layer(axum_sqlx_tx::Layer::new(pool.clone())),
+        );
+
+    let server = axum::Server::bind(&([0, 0, 0, 0], 0).into()).serve(app.into_make_service());
+
+    println!("Listening on {}", server.local_addr());
+    server.await?;
+
+    Ok(())
+}
+
+async fn list_numbers(mut tx: Tx) -> Result<Json<Vec<i32>>, DbError> {
+    let numbers: Vec<(i32,)> = sqlx::query_as("SELECT * FROM numbers")
+        .fetch_all(&mut tx)
+        .await?;
+
+    Ok(Json(numbers.into_iter().map(|n| n.0).collect()))
+}
+
+async fn generate_number(mut tx: Tx) -> Result<(StatusCode, Json<i32>), DbError> {
+    let (number,): (i32,) =
+        sqlx::query_as("INSERT INTO numbers VALUES (random()) RETURNING number;")
+            .fetch_one(&mut tx)
+            .await?;
+
+    // Simulate a possible error – in reality this could be something like interacting with another
+    // service, or running another query.
+    let status = if number > 0 {
+        StatusCode::OK
+    } else {
+        StatusCode::IM_A_TEAPOT
+    };
+
+    // no need to explicitly resolve!
+    Ok((status, Json(number)))
+}
+
+// An sqlx::Error wrapper that implements IntoResponse
+struct DbError(sqlx::Error);
+
+impl From<sqlx::Error> for DbError {
+    fn from(error: sqlx::Error) -> Self {
+        Self(error)
+    }
+}
+
+impl IntoResponse for DbError {
+    fn into_response(self) -> axum::response::Response {
+        println!("ERROR: {}", self.0);
+        (StatusCode::INTERNAL_SERVER_ERROR, "internal server error").into_response()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,8 @@
 //!
 //! [examples]: https://github.com/wasdacraic/axum-sqlx-tx/tree/master/examples
 
+#![cfg_attr(doc, deny(warnings))]
+
 mod layer;
 mod slot;
 mod tx;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,74 @@
+//! Request-bound [SQLx] transactions for [axum].
+//!
+//! [SQLx]: https://github.com/launchbadge/sqlx#readme
+//! [axum]: https://github.com/tokio-rs/axum#readme
+//!
+//! [`Tx`] is an `axum` [extractor][axum extractors] for obtaining a transaction that's bound to the
+//! HTTP request. A transaction begins the first time the extractor is used for a request, and is
+//! then stored in [request extensions] for use by other middleware/handlers. The transaction is
+//! resolved depending on the status code of the eventual response – successful (HTTP `2XX`)
+//! responses will cause the transaction to be committed, otherwise it will be rolled back.
+//!
+//! This behaviour is often a sensible default, and using the extractor (e.g. rather than directly
+//! using [`sqlx::Transaction`]s) means you can't forget to commit the transactions!
+//!
+//! [axum extractors]: https://docs.rs/axum/latest/axum/#extractors
+//! [request extensions]: https://docs.rs/http/latest/http/struct.Extensions.html
+//!
+//! # Usage
+//!
+//! To use the [`Tx`] extractor, you must first add [`Layer`] to your app:
+//!
+//! ```no_run
+//! # use axum::error_handling::HandleErrorLayer;
+//! # async fn foo() {
+//! let pool = /* any sqlx::Pool */
+//! # sqlx::SqlitePool::connect(todo!()).await.unwrap();
+//! let app = axum::Router::new()
+//!     // .route(...)s
+//!     .layer(
+//!         tower::ServiceBuilder::new()
+//!             // The transaction is committed by the middleware so an error is possible and must
+//!             // be converted into a response
+//!             .layer(HandleErrorLayer::new(|error: sqlx::Error| async move {
+//!                 http::StatusCode::INTERNAL_SERVER_ERROR
+//!             }))
+//!             // Now we can add the middleware
+//!             .layer(axum_sqlx_tx::Layer::new(pool)),
+//!     );
+//! # axum::Server::bind(todo!()).serve(app.into_make_service());
+//! # }
+//! ```
+//!
+//! You can then simply add [`Tx`] as an argument to your handlers:
+//!
+//! ```no_run
+//! use axum_sqlx_tx::Tx;
+//! use sqlx::Sqlite;
+//!
+//! async fn create_user(mut tx: Tx<Sqlite>, /* ... */) {
+//!     // `&mut Tx` implements `sqlx::Executor`
+//!     let user = sqlx::query("INSERT INTO users (...) VALUES (...)")
+//!         .fetch_one(&mut tx)
+//!         .await
+//!         .unwrap();
+//!
+//!     // `Tx` also implements `Deref<Target = sqlx::Transaction>` and `DerefMut`
+//!     use sqlx::Acquire;
+//!     let inner = tx.begin().await.unwrap();
+//!     /* ... */
+//! }
+//! ```
+//!
+//! If you forget to add the middleware you'll get [`Error::MissingExtension`] (internal server
+//! error) when using the extractor. You'll also get an error ([`Error::OverlappingExtractors`]) if
+//! you have multiple `Tx` arguments in a single handler, or call `Tx::from_request` multiple times
+//! in a single middleware.
+//!
+//! See [`examples/`][examples] in the repo for more examples.
+//!
+//! [examples]: https://github.com/wasdacraic/axum-sqlx-tx/tree/master/examples
+
 mod layer;
 mod slot;
 mod tx;


### PR DESCRIPTION
- e241e9e **doc: flesh out the documentation**

  All types are now well covered for prose, and there are a few more
  examples in the docs. Additionally, a full example has been added.

- 7f9bd79 **chore: bump version**


- ce810c1 **ci: add `cargo doc` check to CI**

