### PR TITLE
chore: bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-sqlx-tx"
 description = "Request-scoped SQLx transactions for axum"
-version = "0.3.0"
+version = "0.4.0"
 license = "MIT"
 repository = "https://github.com/wasdacraic/axum-sqlx-tx/"
 edition = "2021"


### PR DESCRIPTION
- 7be98a3 **chore: bump version**

  This a minor bump since upgrading SQLx was in fact a breaking change.
