### PR TITLE
Treat both 2XX and 3XX responses as successful.

### DIFF
--- a/src/layer.rs
+++ b/src/layer.rs
@@ -117,7 +117,7 @@ where
         Box::pin(async move {
             let res = res.await.unwrap(); // inner service is infallible
 
-            if res.status().is_success() {
+            if !res.status().is_server_error() && !res.status().is_client_error() {
                 if let Err(error) = transaction.commit().await {
                     return Ok(E::from(Error::Database { error }).into_response());
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,8 @@
 //! [`Tx`] is an `axum` [extractor][axum extractors] for obtaining a transaction that's bound to the
 //! HTTP request. A transaction begins the first time the extractor is used for a request, and is
 //! then stored in [request extensions] for use by other middleware/handlers. The transaction is
-//! resolved depending on the status code of the eventual response – successful (HTTP `2XX`)
-//! responses will cause the transaction to be committed, otherwise it will be rolled back.
+//! resolved depending on the status code of the eventual response – successful (HTTP `2XX` or
+//! `3XX`) responses will cause the transaction to be committed, otherwise it will be rolled back.
 //!
 //! This behaviour is often a sensible default, and using the extractor (e.g. rather than directly
 //! using [`sqlx::Transaction`]s) means you can't forget to commit the transactions!


### PR DESCRIPTION
The `303 See Other` response is often used to direct clients to another page after successfully creating a new resource, and such behavior is encouraged by web standards.

Thanks for this module, it's very useful. I'm using it to develop a web application.