### PR TITLE
Upgrade axum to v0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,7 @@ tower-service = "0.3.1"
 
 [dev-dependencies]
 axum-sqlx-tx = { path = ".", features = ["runtime-tokio-rustls", "sqlite"] }
-axum = "0.6.1"
+axum = { version = "0.6.1", features = ["macros"] }
 hyper = "0.14.17"
-tempfile = "3.3.0"
 tokio = { version = "1.17.0", features = ["macros"] }
 tower = "0.4.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ runtime-tokio-rustls = ["sqlx/runtime-tokio-rustls"]
 features = ["all-databases", "runtime-tokio-rustls"]
 
 [dependencies]
-axum-core = "0.2.1"
+axum-core = "0.3"
 bytes = "1.1.0"
 futures-core = "0.3.21"
 http = "0.2.6"
@@ -40,7 +40,7 @@ tower-service = "0.3.1"
 
 [dev-dependencies]
 axum-sqlx-tx = { path = ".", features = ["runtime-tokio-rustls", "sqlite"] }
-axum = "0.5.1"
+axum = "0.6.1"
 hyper = "0.14.17"
 tempfile = "3.3.0"
 tokio = { version = "1.17.0", features = ["macros"] }

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -19,6 +19,7 @@ pub struct Layer<DB: sqlx::Database> {
     pool: sqlx::Pool<DB>,
 }
 
+// can't simply derive because `DB` isn't `Clone`
 impl<DB: sqlx::Database> Clone for Layer<DB> {
     fn clone(&self) -> Self {
         Self {

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -50,7 +50,7 @@ impl<DB: sqlx::Database> Tx<DB> {
     /// response). This method allows the transaction to be committed explicitly.
     ///
     /// **Note:** trying to use the `Tx` extractor again after calling `commit` will currently
-    /// generate [`Error::OverlappingExtractors`] errors. This may change in future.
+    /// generate [`TxRejection::OverlappingExtractors`] errors. This may change in future.
     pub async fn commit(self) -> Result<(), sqlx::Error> {
         self.0.steal().commit().await
     }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,19 +1,32 @@
+use std::str::FromStr;
+
 use axum::{error_handling::HandleErrorLayer, handler::Handler};
+use axum_sqlx_tx::TxLayerError;
 use http::StatusCode;
-use sqlx::{sqlite::SqliteArguments, Arguments as _};
-use tempfile::NamedTempFile;
+use sqlx::{
+    sqlite::{SqliteArguments, SqliteConnectOptions},
+    Arguments as _, SqlitePool,
+};
 use tower::{ServiceBuilder, ServiceExt};
 
 type Tx = axum_sqlx_tx::Tx<sqlx::Sqlite>;
 
 #[tokio::test]
 async fn commit_on_success() {
-    let (_db, pool, response) = build_app(|mut tx: Tx| async move {
+    // arrange
+    let pool =
+        init_database(&["CREATE TABLE IF NOT EXISTS users (id INT PRIMARY KEY, name TEXT);"])
+            .await
+            .unwrap();
+
+    // act
+    let response = call_handler(pool.clone(), |mut tx: Tx| async move {
         let (_, name) = insert_user(&mut tx, 1, "huge hackerman").await;
         format!("hello {name}")
     })
     .await;
 
+    // assert
     assert!(response.status.is_success());
     assert_eq!(response.body, "hello huge hackerman");
 
@@ -26,12 +39,20 @@ async fn commit_on_success() {
 
 #[tokio::test]
 async fn rollback_on_error() {
-    let (_db, pool, response) = build_app(|mut tx: Tx| async move {
+    // arrange
+    let pool =
+        init_database(&["CREATE TABLE IF NOT EXISTS users (id INT PRIMARY KEY, name TEXT);"])
+            .await
+            .unwrap();
+
+    // act
+    let response = call_handler(pool.clone(), |mut tx: Tx| async move {
         insert_user(&mut tx, 1, "michael oxmaul").await;
         http::StatusCode::BAD_REQUEST
     })
     .await;
 
+    // assert
     assert!(response.status.is_client_error());
     assert!(response.body.is_empty());
 
@@ -40,13 +61,21 @@ async fn rollback_on_error() {
 
 #[tokio::test]
 async fn explicit_commit() {
-    let (_db, pool, response) = build_app(|mut tx: Tx| async move {
+    // arrange
+    let pool =
+        init_database(&["CREATE TABLE IF NOT EXISTS users (id INT PRIMARY KEY, name TEXT);"])
+            .await
+            .unwrap();
+
+    // act
+    let response = call_handler(pool.clone(), |mut tx: Tx| async move {
         insert_user(&mut tx, 1, "michael oxmaul").await;
         tx.commit().await.unwrap();
         http::StatusCode::BAD_REQUEST
     })
     .await;
 
+    // assert
     assert!(response.status.is_client_error());
     assert!(response.body.is_empty());
 
@@ -58,7 +87,10 @@ async fn explicit_commit() {
 
 #[tokio::test]
 async fn missing_layer() {
+    //arrange
     let app = axum::Router::new().route("/", axum::routing::get(|_: Tx| async move {}));
+
+    // act
     let response = app
         .oneshot(
             http::Request::builder()
@@ -69,6 +101,7 @@ async fn missing_layer() {
         .await
         .unwrap();
 
+    // assert
     assert!(response.status().is_server_error());
 
     let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
@@ -80,13 +113,65 @@ async fn missing_layer() {
 
 #[tokio::test]
 async fn overlapping_extractors() {
-    let (_, _, response) = build_app(|_: Tx, _: Tx| async move {}).await;
+    // arrange
+    let pool = init_database(&[]).await.unwrap();
 
+    // act
+    let response = call_handler(pool.clone(), |_: Tx, _: Tx| async move {}).await;
+
+    // assert
     assert!(response.status.is_server_error());
     assert_eq!(
         response.body,
         format!("{}", axum_sqlx_tx::TxRejection::OverlappingExtractors)
     );
+}
+
+#[tokio::test]
+async fn rollback_during_commit_error_on_tx_layer() {
+    // arrange
+    let pool = init_database(&[
+        "CREATE TABLE IF NOT EXISTS users (id INT PRIMARY KEY);",
+        r#"
+            CREATE TABLE IF NOT EXISTS comments (
+                id INT PRIMARY KEY,
+                user_id INT,
+                FOREIGN KEY (user_id) REFERENCES users(id) DEFERRABLE INITIALLY DEFERRED
+            );
+        "#,
+    ])
+    .await
+    .unwrap();
+
+    // act
+    let response = call_handler(pool.clone(), |mut tx: Tx| async move {
+        sqlx::query("INSERT INTO users VALUES (1)")
+            .execute(&mut tx)
+            .await
+            .unwrap();
+
+        sqlx::query("INSERT INTO comments VALUES (1, random())")
+            .execute(&mut tx)
+            .await
+            .unwrap();
+    })
+    .await;
+
+    // assert
+    assert!(response.status.is_server_error());
+    assert_eq!(response.body, "error during commit");
+
+    let users_count: i32 = sqlx::query_scalar("SELECT COUNT(*) FROM users")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let comments_count: i32 = sqlx::query_scalar("SELECT COUNT(*) FROM comments")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    assert_eq!(users_count, 0);
+    assert_eq!(comments_count, 0);
 }
 
 async fn insert_user(tx: &mut Tx, id: i32, name: &str) -> (i32, String) {
@@ -114,29 +199,26 @@ struct Response {
     body: axum::body::Bytes,
 }
 
-async fn build_app<H, T>(handler: H) -> (NamedTempFile, sqlx::SqlitePool, Response)
-where
-    H: Handler<T, ()>,
-    T: 'static,
-{
-    let db = NamedTempFile::new().unwrap();
-    let pool = sqlx::SqlitePool::connect(&format!("sqlite://{}", db.path().display()))
-        .await
-        .unwrap();
+async fn init_database(init_statements: &[&str]) -> Result<SqlitePool, sqlx::Error> {
+    let pool = SqlitePool::connect_with(
+        SqliteConnectOptions::from_str("sqlite::memory:")?.foreign_keys(true),
+    )
+    .await?;
 
-    sqlx::query("CREATE TABLE IF NOT EXISTS users (id INT PRIMARY KEY, name TEXT);")
-        .execute(&pool)
-        .await
-        .unwrap();
+    for &statement in init_statements {
+        sqlx::query(statement).execute(&pool).await?;
+    }
 
+    Ok(pool)
+}
+
+async fn call_handler<T: 'static>(pool: SqlitePool, handler: impl Handler<T, ()>) -> Response {
     let app = axum::Router::new()
         .route("/", axum::routing::get(handler))
         .layer(
             ServiceBuilder::new()
-                .layer(HandleErrorLayer::new(|err| async move {
-                    println!("Error occurred while committing the transaction : {err:?}");
-
-                    (StatusCode::INTERNAL_SERVER_ERROR, "internal server error")
+                .layer(HandleErrorLayer::new(|_err: TxLayerError| async move {
+                    (StatusCode::INTERNAL_SERVER_ERROR, "error during commit")
                 }))
                 .layer(axum_sqlx_tx::Layer::new(pool.clone())),
         )
@@ -151,8 +233,9 @@ where
         )
         .await
         .unwrap();
+
     let status = response.status();
     let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
 
-    (db, pool, Response { status, body })
+    Response { status, body }
 }


### PR DESCRIPTION
- Upgraded axum to v0.6
- Implemented `FromRequestParts` for `Tx` instead of `FromRequestParts` so that it won't consume the request body
- Implemented `Clone` for `axum_sqlx_tx::Layer` as it is needed by axum layer
- Since `Error` type can't be cloned, removed it from the `axum_sqlx_tx::Layer`.
  - For custom error response for `axum_sqlx_tx::Layer` use [`axum::error_handling::HandleErrorLayer`](https://docs.rs/axum/0.6.0/axum/error_handling/index.html#applying-fallible-middleware)
  - For customizing error response for extractor rejections use custom extractors. See the [customize-extractor-error](https://github.com/tokio-rs/axum/blob/axum-v0.6.0/examples/customize-extractor-error/src/main.rs) example for more details