### PR TITLE
Upgrade `axum` to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-sqlx-tx"
 description = "Request-scoped SQLx transactions for axum"
-version = "0.4.1"
+version = "0.5.0"
 license = "MIT"
 repository = "https://github.com/wasdacraic/axum-sqlx-tx/"
 edition = "2021"
@@ -27,7 +27,7 @@ runtime-tokio-rustls = ["sqlx/runtime-tokio-rustls"]
 features = ["all-databases", "runtime-tokio-rustls"]
 
 [dependencies]
-axum-core = "0.2.1"
+axum-core = "0.3"
 bytes = "1.1.0"
 futures-core = "0.3.21"
 http = "0.2.6"
@@ -40,7 +40,7 @@ tower-service = "0.3.1"
 
 [dev-dependencies]
 axum-sqlx-tx = { path = ".", features = ["runtime-tokio-rustls", "sqlite"] }
-axum = "0.5.1"
+axum = "0.6.4"
 hyper = "0.14.17"
 tempfile = "3.3.0"
 tokio = { version = "1.17.0", features = ["macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,15 +28,15 @@ features = ["all-databases", "runtime-tokio-rustls"]
 
 [dependencies]
 axum-core = "0.3"
-bytes = "1.1.0"
-futures-core = "0.3.21"
-http = "0.2.6"
-http-body = "0.4.4"
-parking_lot = "0.12.0"
+bytes = "1"
+futures-core = "0.3"
+http = "0.2"
+http-body = "0.4"
+parking_lot = "0.12"
 sqlx = { version = "0.6", default-features = false }
-thiserror = "1.0.30"
-tower-layer = "0.3.1"
-tower-service = "0.3.1"
+thiserror = "1"
+tower-layer = "0.3"
+tower-service = "0.3"
 
 [dev-dependencies]
 axum-sqlx-tx = { path = ".", features = ["runtime-tokio-rustls", "sqlite"] }

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -53,6 +53,15 @@ impl<DB: sqlx::Database> Layer<DB> {
     }
 }
 
+impl<DB: sqlx::Database, E> Clone for Layer<DB, E> {
+    fn clone(&self) -> Self {
+        Self {
+            pool: self.pool.clone(),
+            _error: self._error,
+        }
+    }
+}
+
 impl<DB: sqlx::Database, S, E> tower_layer::Layer<S> for Layer<DB, E> {
     type Service = Service<DB, S, E>;
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -188,7 +188,7 @@ struct Response {
 
 async fn build_app<H, T>(handler: H) -> (NamedTempFile, sqlx::SqlitePool, Response)
 where
-    H: axum::handler::Handler<T, axum::body::Body>,
+    H: axum::handler::Handler<T, (), axum::body::Body>,
     T: 'static,
 {
     let db = NamedTempFile::new().unwrap();


### PR DESCRIPTION
- 88afc3a **chore!: upgrade `axum` to 0.6**

  BREAKING CHANGE: The library is no longer compatible with axum 0.5.

- 302717b **chore: drop lower bounds on dependency versions**

  This assumes we have no dependencies on features introduced in
  minor/patch releases of our dependencies, which is a reasonable
  assumption.
